### PR TITLE
Ensure Travis CI builds are running against all LTS + stable Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-    - "6"
-    - "node"
+- 7 # Current stable
+- 6 # Active LTS until 2018-04-18
+- 4 # Active LTS until 2017-04-01
 
 cache:
     directories:


### PR DESCRIPTION
This matches [The Lounge's Travis config file](https://github.com/thelounge/lounge/blob/097d7377f9d03da3c3d6d5dc514d43fcf15c0d60/.travis.yml#L2-L5).
Setting explicit stable version makes sure release of v8 will not silently bump unrelated builds.