### PR TITLE
Use Travis CI cache for downloaded files instead of installed ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
     - "node"
 
 cache:
-  directories:
-    - ~/.npm
+    directories:
+        - ~/.npm
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
     - "node"
 
 cache:
-    directories:
-    - node_modules # NPM packages
+  directories:
+    - ~/.npm
 
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This is a straight port from [The Lounge](https://github.com/thelounge/lounge), more specifically from https://github.com/thelounge/lounge/commit/6dac7b1897f135ca0aeae3b54ca974f8a497b19f.

This allows for a more meaningful build: if a newer version of a sub-package breaks, builds would still pass as it uses the cached version. This uses a cache for downloaded packages instead.

See https://docs.npmjs.com/cli/cache#configuration and https://docs.npmjs.com/files/folders#node-modules.